### PR TITLE
update shebang line to use `/usr/bin/env`

### DIFF
--- a/minimgmods.php
+++ b/minimgmods.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /*
  * minimgmods.php

--- a/minmods.php
+++ b/minmods.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /*
  * minmods.php


### PR DESCRIPTION
This PR changes the shebang's directive to use `env` for slightly improved cross-Unix-like-OS compatibility.

Tested on RHEL6 and FreeBSD. 